### PR TITLE
Remove `app_name` to stop client shadowing

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.eggheadgames.aboutbox">
 
-    <application android:label="@string/app_name">
+    <application>
         <activity
             android:name="com.eggheadgames.aboutbox.activity.AboutActivity"
             android:theme="@style/AppTheme.MaterialAboutActivity" />

--- a/library/src/main/res/values-pt/strings.xml
+++ b/library/src/main/res/values-pt/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">AboutBox</string>
     <string name="egab_leave_review">Avaliar</string>
     <string name="egab_contact_support">Contactar o Suporte</string>
     <string name="egab_try_other_apps">Experimentar outras aplicações</string>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">AboutBox</string>
     <string name="egab_leave_review">Leave Review</string>
     <string name="egab_contact_support">Contact Support</string>
     <string name="egab_try_other_apps">Try Other Apps</string>


### PR DESCRIPTION
Close #13

We weren't using it anyway, so let's remove it to avoid any potential conflicts.