### PR TITLE
Various Minor Fixes

### DIFF
--- a/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
@@ -8,8 +8,8 @@ import android.widget.Toast;
 
 public final class AboutBoxUtils {
 
-    public static String playStoreAppURI = "https://play.google.com/store/apps/details?id=";
-    public static String amznStoreAppURI = "https://www.amazon.com/gp/mas/dl/android?p=";
+    public final static String playStoreAppURI = "https://play.google.com/store/apps/details?id=";
+    public final static String amznStoreAppURI = "https://www.amazon.com/gp/mas/dl/android?p=";
 
     private AboutBoxUtils() {
         //nothing

--- a/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
@@ -66,8 +66,9 @@ public final class AboutBoxUtils {
         String webURI = null;
         switch (buildType) {
             case GOOGLE:
-                appURI = "market://search?q=pub:" + publisher;
-                webURI = "http://play.google.com/store/search?q=pub:" + publisher;
+                // see: https://developer.android.com/distribute/marketing-tools/linking-to-google-play.html#OpeningPublisher
+                appURI = "market://dev?id=" + publisher;
+                webURI = "http://play.google.com/store/dev?id=" + publisher;
                 break;
             case AMAZON:
                 appURI = "amzn://apps/android?showAll=1&p=" + packageName;

--- a/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
@@ -8,6 +8,9 @@ import android.widget.Toast;
 
 public final class AboutBoxUtils {
 
+    public static String playStoreAppURI = "https://play.google.com/store/apps/details?id=";
+    public static String amznStoreAppURI = "https://www.amazon.com/gp/mas/dl/android?p=";
+
     private AboutBoxUtils() {
         //nothing
     }
@@ -49,11 +52,11 @@ public final class AboutBoxUtils {
         switch (buildType) {
             case GOOGLE:
                 appURI = "market://details?id=" + packageName;
-                webURI = "http://play.google.com/store/apps/details?id=" + packageName;
+                webURI = playStoreAppURI + packageName;
                 break;
             case AMAZON:
                 appURI = "amzn://apps/android?p=" + packageName;
-                webURI = "http://www.amazon.com/gp/mas/dl/android?p=" + packageName;
+                webURI = amznStoreAppURI + packageName;
                 break;
             default:
                 //nothing

--- a/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
@@ -69,7 +69,7 @@ public final class AboutBoxUtils {
         String webURI = null;
         switch (buildType) {
             case GOOGLE:
-                // see: https://developer.android.com/distribute/marketing-tools/linking-to-google-play.html#OpeningPublisher
+                // per: https://developer.android.com/distribute/marketing-tools/linking-to-google-play.html#OpeningPublisher
                 appURI = "market://dev?id=" + publisher;
                 webURI = "http://play.google.com/store/dev?id=" + publisher;
                 break;

--- a/library/src/main/java/com/eggheadgames/aboutbox/activity/AboutActivity.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/activity/AboutActivity.java
@@ -184,7 +184,7 @@ public class AboutActivity extends MaterialAboutActivity {
         if (!TextUtils.isEmpty(config.webHomePage)) {
             card.addItem(new MaterialAboutActionItem.Builder()
                     .text(R.string.egab_web_label)
-                    .subText(config.webHomePage.replace("https://", "").replace("http://", "").replace("/", ""))
+                    .subText(config.webHomePage.replaceFirst("^https?://", "").replaceAll("/$", ""))
                     .icon(R.drawable.ic_web_black_24dp)
                     .setOnClickListener(new MaterialAboutItemOnClickListener() {
                         @Override

--- a/library/src/main/java/com/eggheadgames/aboutbox/share/ShareUtil.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/share/ShareUtil.java
@@ -2,7 +2,9 @@ package com.eggheadgames.aboutbox.share;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.text.TextUtils;
 
+import com.eggheadgames.aboutbox.AboutBoxUtils;
 import com.eggheadgames.aboutbox.AboutConfig;
 
 public final class ShareUtil {
@@ -17,7 +19,22 @@ public final class ShareUtil {
         Intent intent2 = new Intent();
         intent2.setAction(Intent.ACTION_SEND);
         intent2.setType("text/plain");
-        intent2.putExtra(Intent.EXTRA_TEXT, config.shareMessage);
+
+        String shareMessage = config.shareMessage;
+
+        if (!TextUtils.isEmpty(config.packageName) && !TextUtils.isEmpty(shareMessage) && config.buildType != null) {
+            switch (config.buildType) {
+                case GOOGLE:
+                    shareMessage = AboutBoxUtils.playStoreAppURI + config.packageName;
+                    break;
+                case AMAZON:
+                    shareMessage = AboutBoxUtils.amznStoreAppURI + config.packageName;
+                    break;
+            }
+        }
+
+        intent2.putExtra(Intent.EXTRA_TEXT, shareMessage);
+
         activity.startActivity(Intent.createChooser(intent2, config.sharingTitle));
     }
 }

--- a/library/src/main/java/com/eggheadgames/aboutbox/share/ShareUtil.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/share/ShareUtil.java
@@ -30,6 +30,8 @@ public final class ShareUtil {
                 case AMAZON:
                     shareMessage = AboutBoxUtils.amznStoreAppURI + config.packageName;
                     break;
+                default:
+                    break;
             }
         }
 


### PR DESCRIPTION
- Switched to proper link to Google Play Store Publisher, per official documentation.
  - See: https://developer.android.com/distribute/marketing-tools/linking-to-google-play.html#OpeningPublisher
- Fixed home page URL cleaning for display. 
  - Protocol (```https(s)://```) and trailing slash removed, instead of removing all slashes.
- Added default shareMessage if not set.
  - Set to Google Play or Amazon Store app page.

