### PR TITLE
Handle both publisher or developer page.

### DIFF
--- a/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/AboutBoxUtils.java
@@ -69,9 +69,16 @@ public final class AboutBoxUtils {
         String webURI = null;
         switch (buildType) {
             case GOOGLE:
-                // per: https://developer.android.com/distribute/marketing-tools/linking-to-google-play.html#OpeningPublisher
-                appURI = "market://dev?id=" + publisher;
-                webURI = "http://play.google.com/store/dev?id=" + publisher;
+                // see:
+                // https://developer.android.com/distribute/marketing-tools/linking-to-google-play.html#OpeningPublisher
+                // https://stackoverflow.com/questions/32029408/how-to-open-developer-page-on-google-play-store-market
+                if (publisher.matches("\\d+")) {
+                    webURI = "http://play.google.com/store/dev?id=" + publisher;
+                    appURI = webURI;
+                } else {
+                    appURI = "market://search?q=pub:" + publisher;
+                    webURI = "http://play.google.com/store/search?q=pub:" + publisher;
+                }
                 break;
             case AMAZON:
                 appURI = "amzn://apps/android?showAll=1&p=" + packageName;


### PR DESCRIPTION
Fixing my own bug.

So, I realized two things with `market://dev?id=`...

* It is intended to point a [developer page](https://play.google.com/store/apps/dev?id=6626207141685878216), and not everyone has one.

* It [does not work](https://stackoverflow.com/questions/32029408/how-to-open-developer-page-on-google-play-store-market) with most versions of the Play Store. I confirmed as much:

    ![2017-08-31-090033_36941608455_o](https://user-images.githubusercontent.com/705618/29933834-ea3a2e30-8e2d-11e7-98c8-cd5967fb1336.png)

So to address the issue, I've implemented support for both developer pages or publisher info (package, name, etc.)

If `publisher` is set to all digits, then I'm assuming it is a developer id:

`http://play.google.com/store/dev?id=<publisher>`

If not, I'm using:

 `market://search?q=pub:<publisher>`
`http://play.google.com/store/search?q=pub:<publisher>`

I'm not using a `market://` URL when a developer id is specified since, as previously noted, it does not always work. It doesn't matter since most versions of the Play Store app will automatically open `play.google.com` URLs.

I've [reported the bug](https://issuetracker.google.com/issues/65244694) with Google, but even if they fix it at some point (not holding my breath), this fix will work just fine.

