### PR TITLE
Improve share message

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Android About Box is configured with a set of (mostly) strings for the company n
 
 When triggered from a menu item, it will display the app name, icon and version, provide links to contact support, leave a review, share the app, go to other apps by the same company in the app store -- as well as links to Facebook etc.
 
-You can omit most features if they don't apply (e.g. like website), by not setting the values. 
+You can omit most features if they don't apply (e.g. like website), by not setting the values.
 
 ## Installation Instructions
 
@@ -88,7 +88,7 @@ Add AboutBox configuration to your Application class
         aboutConfig.emailSubject = EMAIL_SUBJECT;
         aboutConfig.emailBody = EMAIL_BODY;
 
-      
+
 ```
 
 ## Open the About Box from your app
@@ -106,6 +106,7 @@ By default, the default Android share intent will be called with the values spec
         aboutConfig.shareMessage = getString(R.string.share_message);
         aboutConfig.sharingTitle = getString(R.string.sharing_title);
 ```
+The `share_message` string will have an app store URL appended to it (appropriately constructed for Google Play or Amazon).
 
 Alternatively, you can provide a custom sharing function (and omit `shareMessage` and `sharingTitle`):
  ```java

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   pre:
     - echo y | android update sdk --no-ui --all --filter tools,platform-tools,android-25
-    - echo y | android update sdk --no-ui --all --filter build-tools-25.0.2
+    - echo y | android update sdk --no-ui --all --filter build-tools-25.0.3
 
 test:
   override:

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,14 +5,14 @@ apply plugin: 'com.github.dcendents.android-maven'
 group='com.github.eggheadgames'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 24
-        versionCode 6
-        versionName "1.3.0"
+        versionCode 7
+        versionName "1.3.1"
     }
     buildTypes {
         release {

--- a/library/src/main/java/com/eggheadgames/aboutbox/share/ShareUtil.java
+++ b/library/src/main/java/com/eggheadgames/aboutbox/share/ShareUtil.java
@@ -25,10 +25,10 @@ public final class ShareUtil {
         if (!TextUtils.isEmpty(config.packageName) && !TextUtils.isEmpty(shareMessage) && config.buildType != null) {
             switch (config.buildType) {
                 case GOOGLE:
-                    shareMessage = AboutBoxUtils.playStoreAppURI + config.packageName;
+                    shareMessage = shareMessage + AboutBoxUtils.playStoreAppURI + config.packageName;
                     break;
                 case AMAZON:
-                    shareMessage = AboutBoxUtils.amznStoreAppURI + config.packageName;
+                    shareMessage = shareMessage + AboutBoxUtils.amznStoreAppURI + config.packageName;
                     break;
                 default:
                     break;


### PR DESCRIPTION
Not sure if this was an intended change previously @ethauvin, but I'm prepending the share message before the URL. I.e. so you can now have a message something like:

> "Here is a great app: " + app store url 